### PR TITLE
# Release 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.1
+
+### Bugfix
+- If recipe to load after reboot includes parameter for FlowConfig module, both modules will block each other (fix needs CSK_Module_FlowConfig v1.1.0)
+
 ## Release 1.0.0
 - Initial commit

--- a/CSK_Module_RecipeManager/project.mf.xml
+++ b/CSK_Module_RecipeManager/project.mf.xml
@@ -281,7 +281,7 @@ Beside of this, it is possible to load a recipe via an external event. To do so,
             </crown>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">1.0.0</meta>
+        <meta key="version">1.0.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_RecipeManager/scripts/Configuration/RecipeManager/RecipeManager_Controller.lua
+++ b/CSK_Module_RecipeManager/scripts/Configuration/RecipeManager/RecipeManager_Controller.lua
@@ -502,6 +502,12 @@ local function setFlowConfigPriority(status)
 end
 Script.serveFunction('CSK_RecipeManager.setFlowConfigPriority', setFlowConfigPriority)
 
+--- Function to load parameters related to status if FlowConfig module is ready
+local function tempLoadConfig()
+  local dereg = Script.deregister("CSK_FlowConfig.OnNewStatusFlowConfigReady", tempLoadConfig)
+  loadParameters()
+end
+
 --- Function to react on initial load of persistent parameters
 local function handleOnInitialDataLoaded()
 
@@ -521,7 +527,12 @@ local function handleOnInitialDataLoaded()
       end
 
       if recipeManager_Model.parameterLoadOnReboot then
-        loadParameters()
+        if CSK_FlowConfig then
+          -- If FlowConfig module is available, wait till it is ready (otherwise it is possible that modules block each other)
+          Script.register("CSK_FlowConfig.OnNewStatusFlowConfigReady", tempLoadConfig)
+        else
+          loadParameters()
+        end
       end
       Script.notifyEvent('RecipeManager_OnDataLoadedOnReboot')
     end

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For further information check out the [documentation](https://raw.githack.com/SI
 
 ## Information
 
+If used together with CSK_Module_FlowConfig, please make sure to use a version >=1.1.0.
+
 Tested on  
 
 |Device|Firmware|Module version|

--- a/docu/CSK_Module_RecipeManager.html
+++ b/docu/CSK_Module_RecipeManager.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_RecipeManager 1.0.0</title>
+<title>Documentation - CSK_Module_RecipeManager 1.0.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,11 +615,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_RecipeManager 1.0.0</h1>
+<h1>Documentation - CSK_Module_RecipeManager 1.0.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 1.0.0,</span>
-<span id="revdate">2024-08-14</span>
+<span id="revnumber">version 1.0.1,</span>
+<span id="revdate">2024-12-11</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -754,11 +754,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-14</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-12-11</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -3499,8 +3499,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 1.0.0<br>
-Last updated 2024-08-14 18:22:29 +0200
+Version 1.0.1<br>
+Last updated 2024-12-11 11:03:10 +0100
 </div>
 </div>
 <script type="text/javascript">


### PR DESCRIPTION
# Version 1.0.1

## Bugfix
- If recipe to load after reboot includes parameter for FlowConfig module, both modules will block each other (fix needs CSK_Module_FlowConfig v1.1.0)

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
