### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.2
+
+### Bugfix
+- Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
+- UI differs if deployed via Appstudio or VS Code AppSpace SDK
+- Fullscreen icon of iFrame was visible
+- LuaLoadAllEngineAPI app key was set to true
+
 ## Release 1.0.1
 
 ### Bugfix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Release 1.0.1
+
+### Bugfix
+- If recipe to load after reboot includes parameter for FlowConfig module, both modules will block each other (fix needs CSK_Module_FlowConfig v1.1.0)
+
 ## Release 1.0.0
 - Initial commit

--- a/CSK_Module_RecipeManager/pages/pages/CSK_Module_RecipeManager/CSK_Module_RecipeManager.css
+++ b/CSK_Module_RecipeManager/pages/pages/CSK_Module_RecipeManager/CSK_Module_RecipeManager.css
@@ -86,5 +86,5 @@
 
 .myCustomButton_CSK_Module_RecipeManager {
   border-radius: 30px;
-  padding-right: 0px;
+  padding: 11px;
 }

--- a/CSK_Module_RecipeManager/pages/pages/CSK_Module_RecipeManager/CSK_Module_RecipeManager.html
+++ b/CSK_Module_RecipeManager/pages/pages/CSK_Module_RecipeManager/CSK_Module_RecipeManager.html
@@ -6,13 +6,12 @@
         <layout-row id="RowLayout6">
             <layout-column id="ColumnLayout2" style="align-items: stretch">
                 <layout-row id="RowLayout7" style="align-items: baseline">
-                    <davinci-value-display id="VD_Title" class="myCustomLabel_CSK_Module_RecipeManager"
-                        value="Recipe Manager">
-                    </davinci-value-display>
+                    <h1 id="Heading_Title" class="myCustomLabel_CSK_Module_RecipeManager">
+                        Recipe Manager
+                    </h1>
                     <davinci-value-display id="VD_Version">
-                        <crown-edpws-binding property="value" name="CSK_RecipeManager/OnNewStatusModuleVersion"
-                            update-on-resume>
-                        </crown-edpws-binding>
+                        <crown-on property="value" crown-event="CSK_RecipeManager/OnNewStatusModuleVersion">
+                        </crown-on>
                     </davinci-value-display>
                 </layout-row>
             </layout-column>
@@ -66,9 +65,10 @@
                                                                     style="justify-content: center; align-items: center">
                                                                     <davinci-button id="B_LoadConfig"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Load configured parameters from CSK_PersistentData module."
-                                                                        icon="action/history">
+                                                                        type="outline"
+                                                                        title="Load configured parameters from CSK_PersistentData module.">
+                                                                        <davinci-icon icon="action/history">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/loadParameters"
@@ -82,9 +82,10 @@
                                                                     </davinci-button>
                                                                     <davinci-button id="B_SaveConfig"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Save current configured parameters of this module within CSK_PersistentData module."
-                                                                        icon="content/save">
+                                                                        type="outline"
+                                                                        title="Save current configured parameters of this module within CSK_PersistentData module.">
+                                                                        <davinci-icon icon="content/save">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/sendParameters"
@@ -214,19 +215,19 @@
                                 </layout-row>
                                 <layout-row id="RowLayout8">
                                     <layout-column id="ColumnLayout7" style="align-items: stretch">
-										<layout-row id="RowLayout20">
-											<layout-column id="ColumnLayout10" style="align-items: stretch">
-												<curie-callout id="DC_FlowConfigInfo1" type="info"
-													value="FlowConfig priority active.">
-												<crown-edpws-binding property="hidden"
-													name="CSK_RecipeManager/OnNewStatusFlowConfigPriority"
-													update-on-resume converter="function(value) {return !value;}">
-												</crown-edpws-binding>
-												</curie-callout>
-											</layout-column>
-											<layout-column id="ColumnLayout22" style="align-items: stretch">
-											</layout-column>
-										</layout-row>
+                                        <layout-row id="RowLayout20">
+                                            <layout-column id="ColumnLayout10" style="align-items: stretch">
+                                                <curie-callout id="DC_FlowConfigInfo1" type="info"
+                                                    value="FlowConfig priority active.">
+                                                    <crown-edpws-binding property="hidden"
+                                                        name="CSK_RecipeManager/OnNewStatusFlowConfigPriority"
+                                                        update-on-resume converter="function(value) {return !value;}">
+                                                    </crown-edpws-binding>
+                                                </curie-callout>
+                                            </layout-column>
+                                            <layout-column id="ColumnLayout22" style="align-items: stretch">
+                                            </layout-column>
+                                        </layout-row>
                                         <layout-row id="RowLayout18">
                                             <layout-column id="ColumnLayout4" style="align-items: stretch">
                                                 <davinci-text-field id="TF_RegisteredEvent" type="text"
@@ -241,10 +242,10 @@
                                                         name="CSK_RecipeManager/setRegisteredEvent"
                                                         path="param/args/event" auto-commit>
                                                     </crown-binding>
-												<crown-edpws-binding property="disabled"
-													name="CSK_RecipeManager/OnNewStatusFlowConfigPriority"
-													update-on-resume>
-												</crown-edpws-binding>
+                                                    <crown-edpws-binding property="disabled"
+                                                        name="CSK_RecipeManager/OnNewStatusFlowConfigPriority"
+                                                        update-on-resume>
+                                                    </crown-edpws-binding>
                                                 </davinci-text-field>
                                             </layout-column>
                                             <layout-column id="ColumnLayout21" style="align-items: stretch">
@@ -280,7 +281,8 @@
                                                     style="justify-content: flex-end; align-items: center">
                                                     <davinci-button id="Button_AddRecipe"
                                                         class="myCustomButton_CSK_Module_RecipeManager" type="outline"
-                                                        icon-position="append" icon="content/add" title="Add recipe">
+                                                        title="Add recipe">
+                                                        <davinci-icon icon="content/add"></davinci-icon>
                                                         <span></span>
                                                         <crown-binding event="submit"
                                                             name="CSK_RecipeManager/addRecipeViaUI" auto-commit>
@@ -288,8 +290,8 @@
                                                     </davinci-button>
                                                     <davinci-button id="Button_RemoveRecipe"
                                                         class="myCustomButton_CSK_Module_RecipeManager" type="outline"
-                                                        icon-position="append" icon="action/delete"
                                                         title="Delete recipe">
+                                                        <davinci-icon icon="action/delete"></davinci-icon>
                                                         <span></span>
                                                         <crown-binding event="submit"
                                                             name="CSK_RecipeManager/deleteRecipeViaUI" auto-commit>
@@ -385,8 +387,9 @@
                                                                     style="justify-content: flex-end">
                                                                     <davinci-button id="Button_AddEditRow"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Add/Edit" icon="content/create">
+                                                                        type="outline" title="Add/Edit">
+                                                                        <davinci-icon icon="content/create">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/updateRecipeConfig"
@@ -395,9 +398,10 @@
                                                                     </davinci-button>
                                                                     <davinci-button id="Button_RemoveRow"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="outline" icon-position="append"
-                                                                        title="Remove selected row of recipe."
-                                                                        icon="action/delete">
+                                                                        type="outline"
+                                                                        title="Remove selected row of recipe.">
+                                                                        <davinci-icon icon="action/delete">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/deleteRecipeOrderIDViaUI"
@@ -431,9 +435,9 @@
                                                                 <layout-row id="RowLayout14">
                                                                     <davinci-button id="Button_SortUp"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="outline" icon-position="append"
-                                                                        icon="navigation/arrow_upward"
-                                                                        title="Set up in order">
+                                                                        type="outline" title="Set up in order">
+                                                                        <davinci-icon icon="navigation/arrow_upward">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/moveTableRowUp"
@@ -442,9 +446,9 @@
                                                                     </davinci-button>
                                                                     <davinci-button id="Button_SortDown"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="outline" icon-position="append"
-                                                                        icon="navigation/arrow_downward"
-                                                                        title="Set down in order">
+                                                                        type="outline" title="Set down in order">
+                                                                        <davinci-icon icon="navigation/arrow_downward">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/moveTableRowDown"
@@ -459,9 +463,10 @@
                                                                     style="justify-content: flex-end">
                                                                     <davinci-button id="Button_LoadRecipe"
                                                                         class="myCustomButton_CSK_Module_RecipeManager"
-                                                                        type="primary" icon-position="append"
-                                                                        title="Load recipe for all configured modules."
-                                                                        icon="navigation/check">
+                                                                        type="primary"
+                                                                        title="Load recipe for all configured modules.">
+                                                                        <davinci-icon icon="navigation/check">
+                                                                        </davinci-icon>
                                                                         <span></span>
                                                                         <crown-binding event="submit"
                                                                             name="CSK_RecipeManager/loadRecipeViaUI"

--- a/CSK_Module_RecipeManager/pages/src/converter.ts
+++ b/CSK_Module_RecipeManager/pages/src/converter.ts
@@ -5,6 +5,14 @@ export function convertToList(value) {
 export function changeStyle(theme) {
   const style: HTMLStyleElement = document.createElement('style');
   style.id ='blub'
+
+  const toggleSW = document.querySelectorAll("davinci-toggle-switch")
+  toggleSW.forEach((userItem) => {
+    const shadowToggle = userItem.shadowRoot
+    const finalToggleSW = shadowToggle?.querySelector('div')
+    finalToggleSW?.classList.add('hasIcon')
+  });
+
   if (theme == 'CSK_Style'){
     var headerToolbar = `.sopasjs-ui-header-toolbar-wrapper { background-color: #FFFFFF; }`
     var uiHeader = `.sopasjs-ui-header>.app-logo { margin-right:0px; }`

--- a/CSK_Module_RecipeManager/pages/src/index.ts
+++ b/CSK_Module_RecipeManager/pages/src/index.ts
@@ -12,6 +12,10 @@ document.addEventListener('sopasjs-ready', () => {
   page_Setup.remove();
 
   setTimeout(() => {
+    const element = document.querySelector("div.sjs-wrapper > div > div.sjs-fullscreen-toggle")
+    if(element) {
+      element.parentElement.removeChild(element)
+    }
     document.title = 'CSK_Module_RecipeManager'
   }, 500);
 })

--- a/CSK_Module_RecipeManager/project.mf.xml
+++ b/CSK_Module_RecipeManager/project.mf.xml
@@ -281,12 +281,12 @@ Beside of this, it is possible to load a recipe via an external event. To do so,
             </crown>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">1.0.1</meta>
+        <meta key="version">1.0.2</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>
         <meta key="crown2-flow-engine">false</meta>
-        <meta key="LuaLoadAllEngineAPI">true</meta>
+        <meta key="LuaLoadAllEngineAPI">false</meta>
         <entry default="CSK_Module_RecipeManager.lua" path="scripts"/>
     </application>
 </manifest>

--- a/CSK_Module_RecipeManager/project.mf.xml
+++ b/CSK_Module_RecipeManager/project.mf.xml
@@ -281,7 +281,7 @@ Beside of this, it is possible to load a recipe via an external event. To do so,
             </crown>
         </crown>
         <meta key="author">SICK AG</meta>
-        <meta key="version">1.0.0</meta>
+        <meta key="version">1.0.1</meta>
         <meta key="priority">low</meta>
         <meta key="copy-protected">false</meta>
         <meta key="read-protected">false</meta>

--- a/CSK_Module_RecipeManager/scripts/Configuration/RecipeManager/RecipeManager_Controller.lua
+++ b/CSK_Module_RecipeManager/scripts/Configuration/RecipeManager/RecipeManager_Controller.lua
@@ -502,6 +502,12 @@ local function setFlowConfigPriority(status)
 end
 Script.serveFunction('CSK_RecipeManager.setFlowConfigPriority', setFlowConfigPriority)
 
+--- Function to load parameters related to status if FlowConfig module is ready
+local function tempLoadConfig()
+  local dereg = Script.deregister("CSK_FlowConfig.OnNewStatusFlowConfigReady", tempLoadConfig)
+  loadParameters()
+end
+
 --- Function to react on initial load of persistent parameters
 local function handleOnInitialDataLoaded()
 
@@ -521,7 +527,12 @@ local function handleOnInitialDataLoaded()
       end
 
       if recipeManager_Model.parameterLoadOnReboot then
-        loadParameters()
+        if CSK_FlowConfig then
+          -- If FlowConfig module is available, wait till it is ready (otherwise it is possible that modules block each other)
+          Script.register("CSK_FlowConfig.OnNewStatusFlowConfigReady", tempLoadConfig)
+        else
+          loadParameters()
+        end
       end
       Script.notifyEvent('RecipeManager_OnDataLoadedOnReboot')
     end

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tested on
 
 |Device|Firmware|Module version|
 |--|--|--|
+|SICK AppEngine|v1.7.0|v1.0.2|
 |SICK AppEngine|v1.7.0|v1.0.0|
 |SIM1012|v2.4.2|v1.0.0|
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For further information check out the [documentation](https://raw.githack.com/SI
 
 ## Information
 
+If used together with CSK_Module_FlowConfig, please make sure to use a version >=1.1.0.
+
 Tested on  
 
 |Device|Firmware|Module version|

--- a/docu/CSK_Module_RecipeManager.html
+++ b/docu/CSK_Module_RecipeManager.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_RecipeManager 1.0.0</title>
+<title>Documentation - CSK_Module_RecipeManager 1.0.1</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,11 +615,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_RecipeManager 1.0.0</h1>
+<h1>Documentation - CSK_Module_RecipeManager 1.0.1</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 1.0.0,</span>
-<span id="revdate">2024-08-14</span>
+<span id="revnumber">version 1.0.1,</span>
+<span id="revdate">2024-12-11</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
@@ -754,11 +754,11 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.1</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-14</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-12-11</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Author</p></th>
@@ -3499,8 +3499,8 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 1.0.0<br>
-Last updated 2024-08-14 18:22:29 +0200
+Version 1.0.1<br>
+Last updated 2024-12-11 11:03:10 +0100
 </div>
 </div>
 <script type="text/javascript">

--- a/docu/CSK_Module_RecipeManager.html
+++ b/docu/CSK_Module_RecipeManager.html
@@ -6,7 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.12">
 <meta name="author" content="SICK AG">
-<title>Documentation - CSK_Module_RecipeManager 1.0.1</title>
+<title>Documentation - CSK_Module_RecipeManager 1.0.2</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <style>
 /* Stylesheet for CodeRay to match GitHub theme | MIT License | http://foundation.zurb.com */
@@ -615,10 +615,10 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </head>
 <body class="article toc2 toc-left">
 <div id="header">
-<h1>Documentation - CSK_Module_RecipeManager 1.0.1</h1>
+<h1>Documentation - CSK_Module_RecipeManager 1.0.2</h1>
 <div class="details">
 <span id="author" class="author">SICK AG</span><br>
-<span id="revnumber">version 1.0.1,</span>
+<span id="revnumber">version 1.0.2,</span>
 <span id="revdate">2024-12-11</span>
 </div>
 <div id="toc" class="toc2">
@@ -754,7 +754,7 @@ h1,h2,h3,h4,h5,h6{color:#007cc1}
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Version</p></th>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.2</p></td>
 </tr>
 <tr>
 <th class="tableblock halign-left valign-top"><p class="tableblock">Date</p></th>
@@ -3499,7 +3499,7 @@ Script.register(<span class="string"><span class="delimiter">&quot;</span><span 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version 1.0.1<br>
+Version 1.0.2<br>
 Last updated 2024-12-11 11:03:10 +0100
 </div>
 </div>


### PR DESCRIPTION
# Release 1.0.2

## Bugfix
- Legacy bindings of ValueDisplay elements within UI did not work if deployed with VS Code AppSpace SDK
- UI differs if deployed via Appstudio or VS Code AppSpace SDK
- Fullscreen icon of iFrame was visible
- LuaLoadAllEngineAPI app key was set to true

## Following tasks were checked

- [x] Module is coded and structured according to the "Developing guideline for modules" described within the CSK documentation
- [x] All functions/events/parameters are documented within the manifest documentation
- [x] The manifest description of the main CROWN includes main information about the purpose of the module and how to use it in general
- [x] API docu based on the manifest was created and stored within the "docu"-folder of the repository
- [x] Internal LUA code documentation exists for variables and non served functions
- [x] All relevant infos are logged via the SharedLogger 'ModuleLogger'
- [x] Module supports persistent data feature based on 'CSK_Module_PersistentData'
- [x] Module supports user management based on 'CSK_Module_UserManagement'
- [x] No open "ToDos" within the code or at least clearly explained comments why they exist...
- [x] "Version" key in app manifest was updated following semantic versioning (and use '0.x.y' for test / experimental modules which are not yet ready to be officially released)
- [x] Meaningful IDs used for UI elements
- [x] Module was tested on an AppSpace device (at least on SICK AppEngine) with no error message
- [x] README.md is up to date (incl. info of device + firmware the module was tested with)
- [x] CHANGELOG.md is up to date
